### PR TITLE
Add indentation plugin

### DIFF
--- a/nimrod.js
+++ b/nimrod.js
@@ -4,6 +4,8 @@
  * author: Paul Giannaros <paul@giannaros.org>, Gerald Senarclens de Grancy <oss@senarclens.eu>, Flaviu Tamas <tamas.flaviu@gmail.com>
  * revision: 3
  * kate-version: 3.13
+ * 
+ * Note: Unlike everything else, this is licenced under the LGPL
  */
 
 


### PR DESCRIPTION
Doesn't include README changes since I want to avoid merge conflicts, but installation basically comes down to putting it in `~/.kde4/share/apps/katepart/script/indentation/nimrod.js`

Also has a few minor bugs, I'll probably be sending a few more PRs with fixes once they are found.
