### PR TITLE
Update nimrod.xml

### DIFF
--- a/nimrod.xml
+++ b/nimrod.xml
@@ -23,7 +23,7 @@ Improvements:
 	kateversion="2.4"
 	section="Sources"
 	extensions="*.nim"
-	mimetype="text/x-nimrod">
+	mimetype="text/x-nim">
 	
 	<highlighting>
 		<list name="keywords">
@@ -37,13 +37,13 @@ Improvements:
 		</list>
 		
 		<list name="controls">
-			<item> and </item>
 			<item> assert </item> <!-- system -->
 			<item> asm </item>
 			<item> atomic </item>
 			<item> block </item>
 			<item> break </item>
 			<item> case </item>
+			<item> cast </item>
 			<item> compiles </item> <!-- system -->
 			<item> continue </item>
 			<item> declared </item> <!-- system -->
@@ -63,8 +63,6 @@ Improvements:
 			<item> mixin </item>
 			<item> bind </item>
 			<item> new </item> <!-- system -->
-			<item> of </item>
-			<item> or </item>
 			<item> raise </item>
 			<item> return </item>
 			<item> sizeof </item> <!-- system -->
@@ -78,8 +76,8 @@ Improvements:
 		
 		<list name="operators">
 			<item> addr </item>
+			<item> and </item>
 			<item> as </item>
-			<item> cast </item>
 			<item> div </item>
 			<item> in </item>
 			<item> is </item>
@@ -87,6 +85,8 @@ Improvements:
 			<item> mod </item>
 			<item> not </item>
 			<item> notin </item>
+			<item> of </item>
+			<item> or </item>
 			<item> shl </item>
 			<item> shr </item>
 			<item> xor </item>
@@ -106,7 +106,6 @@ Improvements:
 			<item> cstring </item>
 			<item> cuint </item>
 			<item> distinct </item>
-			<item> enum </item>
 			<item> expr </item>
 			<item> float </item>
 			<item> float32 </item>
@@ -118,7 +117,6 @@ Improvements:
 			<item> int32 </item>
 			<item> int64 </item>
 			<item> interface </item>
-			<item> object </item>
 			<item> openarray </item>
 			<item> pointer </item>
 			<item> set </item>
@@ -178,12 +176,14 @@ Improvements:
 				<RegExpr context="Proctar" attribute="Keywords" String="\btemplate\b\s*"/>
 				<RegExpr context="Typetar" attribute="Keywords" String="\btype\b\s*"/>
 				<RegExpr context="Typetar" attribute="Keywords" String="\bconcept\b\s*"/>
+				<RegExpr context="Typetar" attribute="Keywords" String="\bobject\b\s*"/>
+				<RegExpr context="Typetar" attribute="Keywords" String="\benum\b\s*"/>
 				
                 <RegExpr context="#stay" attribute="Hex"      String="0[xX][0-9A-Fa-f][0-9A-Fa-f_]*('(([ui](8|16|32|64))|(f(32|64|128))|[ufd]))?"/>
                 <RegExpr context="#stay" attribute="Octal"    String="0o[0-7][0-7_]*('(([ui](8|16|32|64))|(f(32|64|128))|[ufd]))?"/>
                 <RegExpr context="#stay" attribute="Binary"   String="0[bB][01][01_]*('(([ui](8|16|32|64))|(f(32|64|128))|[ufd]))?"/>
 				<RegExpr context="#stay" attribute="Types"    String="\b_*[A-Z](?:\w|\._*[A-Z])*\b"/>
-				<RegExpr context="#stay" attribute="Funcs"    String="\b\w+\b\s*(?=(\[.*\]\s*)?\()"/>
+				<RegExpr context="#stay" attribute="Funcs"    String="\b\w+\b\s*(?=(\[.*\]\w*)?([\(]|([ ](?![,+\-*/=!^&amp;&lt;&gt;|?]|and|as|div|in|is|isnot|mod|notin|of|or|shl|shr|xor))))"/>
 				
 				<DetectIdentifier/>
 				

--- a/nimrod.xml
+++ b/nimrod.xml
@@ -1,8 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE language SYSTEM "language.dtd">
 
+<!-- 
+Improvements:
+
+- fixed typo: "lamba" is now "lambda"
+- added bind, func, typed, untyped, on, off
+- added multiline strings
+- added multiline comments (with stacking!)
+- added support for hex, binary, and octal numbers
+- added support for numerical literal suffixes (e.g. 'f64)
+- made escape sequences in strings work slightly better (still needs work)
+- changed pragma syntax highlighting to dsAttribute instead of dsDataType
+- doc comments
+- TODO/BUG/FIXME/HACK/XXXX/NOTE comments
+
+-->
+
 <language
-	name="Nimrod"
+	name="Nim"
 	version="1.0"
 	kateversion="2.4"
 	section="Sources"
@@ -15,7 +31,7 @@
 			<item> export </item>
 			<item> import </item>
 			<item> include </item>
-			<item> lamba </item>
+			<item> lambda </item>
 			<item> let </item>
 			<item> var </item>
 		</list>
@@ -45,6 +61,7 @@
 			<item> from </item>
 			<item> if </item>
 			<item> mixin </item>
+			<item> bind </item>
 			<item> new </item> <!-- system -->
 			<item> of </item>
 			<item> or </item>
@@ -117,6 +134,8 @@
 			<item> uint64 </item>
 			<item> varargs </item>
 			<item> void </item>
+			<item> untyped </item>
+			<item> typed </item>
 		</list>
 		
 		<list name="attrs">
@@ -132,6 +151,8 @@
 			<item> inf </item>
 			<item> nil </item>
 			<item> true </item>
+			<item> on </item>
+			<item> off </item>
 		</list>
 		
 		<list name="others">
@@ -153,16 +174,16 @@
 				<RegExpr context="Proctar" attribute="Keywords" String="\bmacro\b\s*"/>
 				<RegExpr context="Proctar" attribute="Keywords" String="\bmethod\b\s*"/>
 				<RegExpr context="Proctar" attribute="Keywords" String="\bproc\b\s*"/>
+				<RegExpr context="Proctar" attribute="Keywords" String="\bfunc\b\s*"/>
 				<RegExpr context="Proctar" attribute="Keywords" String="\btemplate\b\s*"/>
 				<RegExpr context="Typetar" attribute="Keywords" String="\btype\b\s*"/>
+				<RegExpr context="Typetar" attribute="Keywords" String="\bconcept\b\s*"/>
 				
+                <RegExpr context="#stay" attribute="Hex"      String="0[xX][0-9A-Fa-f][0-9A-Fa-f_]*('(([ui](8|16|32|64))|(f(32|64|128))|[ufd]))?"/>
+                <RegExpr context="#stay" attribute="Octal"    String="0o[0-7][0-7_]*('(([ui](8|16|32|64))|(f(32|64|128))|[ufd]))?"/>
+                <RegExpr context="#stay" attribute="Binary"   String="0[bB][01][01_]*('(([ui](8|16|32|64))|(f(32|64|128))|[ufd]))?"/>
 				<RegExpr context="#stay" attribute="Types"    String="\b_*[A-Z](?:\w|\._*[A-Z])*\b"/>
 				<RegExpr context="#stay" attribute="Funcs"    String="\b\w+\b\s*(?=(\[.*\]\s*)?\()"/>
-				<!-- TODO: Note done yet. These are for bracketless func calls... 
-				<RegExpr context="#stay" attribute="Funcs"    String="(^|:|;)\s*\b\w+\b\s*$"/>
-				<RegExpr context="#stay" attribute="Funcs"    String="(^|:|;)\s*\b\w+\b\s+(?=[^ ,:]+((,[^,:]*)+)?\s*$)"/>
-				<RegExpr context="#stay" attribute="Controls" String="(^|:|;)\s*\b\w+\b\s+(?=[^ ,:]+((,[^,:]*)+)?:\s*$)"/>
-				-->
 				
 				<DetectIdentifier/>
 				
@@ -174,20 +195,48 @@
 				<AnyChar context="#stay" attribute="Symbols"  String="+-*/=!@$%^&amp;&lt;&gt;|?"/>
 				
 				<Int        context="#stay"   attribute="Decimal"/>
-				<!-- FIXME: Doesn't seem to be needed
-				<Float      context="#stay"   attribute="Float"/>
-				-->
 				<HlCChar    context="#stay"   attribute="Char"/>
-				<DetectChar context="String"  attribute="String" char="&quot;"/>
-				<DetectChar context="Comment" attribute="Comment" char="#"/>
+                <DetectChar context="string" attribute="String" char="&quot;" beginRegion="String"/>
+                
+				<RegExpr context="DocComment2" attribute="DocComment" String="##[[]"/>
+				<Detect2Chars context="DocComment1" attribute="DocComment" char="#" char1="#"/>
+				<Detect2Chars context="Comment2" attribute="Comment" char="#" char1="[" beginRegion="Comment"/>
+				<DetectChar context="Comment1" attribute="Comment" char="#"/>
 			</context>
 			
-			<context name="String" attribute="String" lineEndContext="#pop">
-				<DetectChar context="#pop" attribute="String" char="&quot;"/>
+            <context name="stringescape" attribute="String Char" lineEndContext="#stay">
+              <RegExpr attribute="String Char" String="\\[&quot;abfnrtv]" context="#stay"/>
+            </context>
+            
+			<context name="string" attribute="String" lineEndContext="#stay">
+                <IncludeRules context="stringescape"/>
+				<DetectChar context="#pop" attribute="String" char="&quot;" endRegion="String"/>
 			</context>
 			
-			<context name="Comment" attribute="Comment" lineEndContext="#pop">
+			<context name="Comment1" attribute="Comment" lineEndContext="#pop">
 				<LineContinue attribute="Comment" context="#stay"/>
+				<RegExpr      attribute="Alert"   context="#stay" String="(BUG|XXXX|HACK)"/>
+				<RegExpr      attribute="Warning" context="#stay" String="(TODO|FIXME)"/>
+				<RegExpr      attribute="Info"    context="#stay" String="(NOTE)"/>
+			</context>
+            
+			<context name="DocComment1" attribute="DocComment" lineEndContext="#pop">
+				<LineContinue attribute="DocComment" context="#stay"/>
+			</context>
+            
+			<context name="DocComment2" attribute="DocComment" lineEndContext="#stay">
+				<LineContinue attribute="DocComment" context="#stay"/>
+                <RegExpr attribute="DocComment" context="DocComment2" String="##[[]" beginRegion="DocComment"/>
+				<RegExpr attribute="DocComment" context="#pop" String="[]]##" endRegion="DocComment"/>
+			</context>
+			
+			<context name="Comment2" attribute="Comment" lineEndContext="#stay">
+				<LineContinue attribute="Comment" context="#stay"/>
+				<RegExpr      attribute="Alert"   context="#stay" String="(BUG|XXXX|HACK)"/>
+				<RegExpr      attribute="Warning" context="#stay" String="(TODO|FIXME)"/>
+				<RegExpr      attribute="Info"    context="#stay" String="(NOTE)"/>
+                <Detect2Chars attribute="Comment" context="Comment2" char="#" char1="[" beginRegion="Comment"/>
+				<Detect2Chars attribute="Comment" context="#pop" char="]" char1="#" endRegion="Comment"/>
 			</context>
 			
 			<context name="Typetar" attribute="TypeDefs" lineEndContext="#pop">
@@ -216,21 +265,21 @@
 				<RegExpr context="#pop" attribute="Types" String="_*[A-Z]\w*"/>
 				<RegExpr context="#pop" attribute="Funcs" String="_*[a-z]\w*(?=\()"/>
 				<RegExpr context="#pop" attribute="Props" String="_*[a-z]\w*(?=\.)"/>
-				<RegExpr context="#pop" attribute="Props" String="_*[a-z]\w*"/> <!-- NOTE: no (?!\.) needed - order dependant -->
+				<RegExpr context="#pop" attribute="Props" String="_*[a-z]\w*"/>
 				<RegExpr context="#pop" attribute="Brackets" String="\.+"/>
 			</context>
 		</contexts>
 		
 		<itemDatas>
-			<itemData name="Normal Text" defStyleNum="dsNormal"   spellChecking="false"/>
-			<itemData name="Keywords"    defStyleNum="dsKeyword"  spellChecking="false"/>
-			<itemData name="Controls"    defStyleNum="dsDataType" spellChecking="false"/>
-			<itemData name="Pragmas"     defStyleNum="dsDataType" spellChecking="false"/>
-			<itemData name="Types"       defStyleNum="dsDataType" spellChecking="false"/>
-			<itemData name="Props"       defStyleNum="dsDataType" spellChecking="false"/>
-			<itemData name="Funcs"       defStyleNum="dsDataType" spellChecking="false"/>
-			<itemData name="Attrs"       defStyleNum="dsDataType" spellChecking="false"/>
-			<itemData name="Others"      defStyleNum="dsOthers"   spellChecking="false"/>
+			<itemData name="Normal Text" defStyleNum="dsNormal"    spellChecking="false"/>
+			<itemData name="Keywords"    defStyleNum="dsKeyword"   spellChecking="false"/>
+			<itemData name="Controls"    defStyleNum="dsDataType"  spellChecking="false"/>
+			<itemData name="Pragmas"     defStyleNum="dsAttribute" spellChecking="false"/>
+			<itemData name="Types"       defStyleNum="dsDataType"  spellChecking="false"/>
+			<itemData name="Props"       defStyleNum="dsDataType"  spellChecking="false"/>
+			<itemData name="Funcs"       defStyleNum="dsDataType"  spellChecking="false"/>
+			<itemData name="Attrs"       defStyleNum="dsDataType"  spellChecking="false"/>
+			<itemData name="Others"      defStyleNum="dsOthers"    spellChecking="false"/>
 			
 			<itemData name="TypeDefs"    defStyleNum="dsDataType" spellChecking="false" bold="true"/>
 			<itemData name="ProcDefs"    defStyleNum="dsString"   spellChecking="false" bold="true"/>
@@ -239,10 +288,18 @@
 			<itemData name="Symbols"     defStyleNum="dsComment"  spellChecking="false"/>
 			
 			<itemData name="Decimal"     defStyleNum="dsDecVal"   spellChecking="false"/>
+			<itemData name="Hex"         defStyleNum="dsBaseN"    spellChecking="false"/>
+			<itemData name="Binary"      defStyleNum="dsBaseN"    spellChecking="false"/>
+			<itemData name="Octal"       defStyleNum="dsBaseN"    spellChecking="false"/>
 			<itemData name="Float"       defStyleNum="dsFloat"    spellChecking="false"/>
 			<itemData name="Char"        defStyleNum="dsChar"     spellChecking="false"/>
 			<itemData name="String"      defStyleNum="dsString"   spellChecking="false"/>
 			<itemData name="Comment"     defStyleNum="dsComment"  spellChecking="false"/>
+			<itemData name="Alert"       defStyleNum="dsAlert"    spellChecking="false" bold="true"/>
+			<itemData name="Warning"     defStyleNum="dsWarning"  spellChecking="false" bold="true"/>
+			<itemData name="Info"        defStyleNum="dsInformation" spellChecking="false" bold="true"/>
+            
+			<itemData name="DocComment"  defStyleNum="dsDocumentation"  spellChecking="true"/>
 		</itemDatas>
 	</highlighting>
 


### PR DESCRIPTION
- fixed typo: "lamba" is now "lambda"
- added bind, func, typed, untyped, on, off
- added multiline strings
- added multiline comments (with stacking!)
- added support for hex, binary, and octal numbers
- added support for numerical literal suffixes (e.g. 'f64)
- made escape sequences in strings work slightly better (still needs work)
- changed pragma syntax highlighting to dsAttribute instead of dsDataType
- added support for doc comments
- TODO/BUG/FIXME/HACK/XXXX/NOTE comments