### PR TITLE
Adapt for KDE5's Kate

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Screenshots
 
 Installation
 ---
-- **Syntax**: Copy `nimrod.xml` to `~/.kde4/share/apps/katepart/syntax/`
-- **Indent**: Copy `nimrod.js` to `~/.kde4/share/apps/katepart/script/indentation/`
+- **Syntax**: Copy `nimrod.xml` to `~/.local/share/katepart5/syntax/`
+- **Indent**: Copy `nimrod.js` to `~/.local/share/katepart5/script/indentation/`
 - **Colors**: Kate > Settings > Configure Kate > Fonts & Colors > (Schema) Import...
 
 License

--- a/nimrod.js
+++ b/nimrod.js
@@ -1,10 +1,14 @@
-/** kate-script
- * name: Nimrod
- * license: LGPL
- * author: Paul Giannaros <paul@giannaros.org>, Gerald Senarclens de Grancy <oss@senarclens.eu>, Flaviu Tamas <tamas.flaviu@gmail.com>
- * revision: 3
- * kate-version: 3.13
- * 
+var katescript = {
+    "name": "Nim",
+    "type": "indentation",
+    "author": "Paul Giannaros <paul@giannaros.org>, Gerald Senarclens de Grancy <oss@senarclens.eu>, Flaviu Tamas <tamas.flaviu@gmail.com>",
+    "license": "LGPL",
+    "revision": 4,
+    "kate-version": "5.1",
+    "indent-languages": ["Nim"],
+    "priority": 0
+};
+/*
  * Note: Unlike everything else, this is licenced under the LGPL
  */
 


### PR DESCRIPTION
I adapted the installation instructions and the indentation script to make in work on modern version of Kate. Tested on Kate 18.08.